### PR TITLE
fix: fix web stacks for aws

### DIFF
--- a/src/providers/providerDeployStrategy/awsDeployStrategy.ts
+++ b/src/providers/providerDeployStrategy/awsDeployStrategy.ts
@@ -601,19 +601,12 @@ export class AwsDeployStrategy implements IDeployStrategy {
     normalizedId: string,
     props: AWSLampStackProps,
   ): void {
-    const lampStackProps: LampStackPropsInterface =
-      props as LampStackPropsInterface;
-    if (!lampStackProps.awsProps) {
-      throw new Error("AWS properties are required for LAMP stack.");
-    }
-    const awsProps: AWSLampStackProps = lampStackProps.awsProps;
-
-    const vpcId = this.getOrDefaultVPCId(scope, normalizedId, awsProps.vpcId);
+    const vpcId = this.getOrDefaultVPCId(scope, normalizedId, props.vpcId);
     const subnetId = this.getOrDefaultSubnetId(
       scope,
       normalizedId,
       vpcId,
-      awsProps.subnetId,
+      props.subnetId,
     );
     const subnetData = new DataAwsSubnet(scope, `${normalizedId}-subnet-az`, {
       id: subnetId,
@@ -653,19 +646,12 @@ export class AwsDeployStrategy implements IDeployStrategy {
     normalizedId: string,
     props: AWSLempStackProps,
   ): void {
-    const lampStackProps: LampStackPropsInterface =
-      props as LampStackPropsInterface;
-    if (!lampStackProps.awsProps) {
-      throw new Error("AWS properties are required for LAMP stack.");
-    }
-    const awsProps: AWSLampStackProps = lampStackProps.awsProps;
-
-    const vpcId = this.getOrDefaultVPCId(scope, normalizedId, awsProps.vpcId);
+    const vpcId = this.getOrDefaultVPCId(scope, normalizedId, props.vpcId);
     const subnetId = this.getOrDefaultSubnetId(
       scope,
       normalizedId,
       vpcId,
-      awsProps.subnetId,
+      props.subnetId,
     );
     const subnetData = new DataAwsSubnet(scope, `${normalizedId}-subnet-az`, {
       id: subnetId,


### PR DESCRIPTION
This pull request refactors the `AwsDeployStrategy` class in `src/providers/providerDeployStrategy/awsDeployStrategy.ts` to simplify the handling of stack properties by removing unnecessary type casting and redundant checks.

Refactoring for simplicity:

* Removed the casting of `props` to `LampStackPropsInterface` and eliminated redundant checks for `awsProps`. The `props` object is now used directly for accessing `vpcId` and `subnetId`, streamlining the code. [[1]](diffhunk://#diff-318af0b3add4dd51eb77613eef32d1bd840a4ea9eab706790070266e33bf1027L604-R609) [[2]](diffhunk://#diff-318af0b3add4dd51eb77613eef32d1bd840a4ea9eab706790070266e33bf1027L656-R654)