### PR TITLE
feat: enhance ubuntu pro features

### DIFF
--- a/infrastructure-assets/configs/ubuntu-pro/entrypoint.sh
+++ b/infrastructure-assets/configs/ubuntu-pro/entrypoint.sh
@@ -6,7 +6,13 @@ if [[ -n "$UBUNTU_PRO_TOKEN" ]]; then
   if pro status | grep -q "is not attached to"; then
     echo "Attaching to Ubuntu Pro..."
     pro attach "$UBUNTU_PRO_TOKEN"
-    pro enable usg
+    echo "Enabling Ubuntu Pro features..."
+    printf "y\n" | pro enable usg || echo "Failed to enable 'usg'"
+    printf "y\n" | pro enable fips-preview || echo "Failed to enable 'fips-preview'"
+    printf "y\n" | pro enable fips-updates || echo "Failed to enable 'fips-updates'"
+    printf "y\n" | pro enable livepatch || echo "Failed to enable 'livepatch'"
+    printf "y\n" | pro enable cis || echo "Failed to enable 'cis'"
+    printf "y\n" | pro enable ros || echo "Failed to enable 'ros'"
   fi
 fi
 


### PR DESCRIPTION
This pull request enhances the Ubuntu Pro setup script by expanding the features enabled during the attachment process. The script now includes additional commands to enable several Ubuntu Pro features, with error handling for each feature activation.

Enhancements to Ubuntu Pro feature enablement:

* [`infrastructure-assets/configs/ubuntu-pro/entrypoint.sh`](diffhunk://#diff-b2e2252032f5594743063e9e4752d4ad788ddf5f6e629e36ec087f55fae122b8L9-R15): Added commands to enable multiple Ubuntu Pro features (`usg`, `fips-preview`, `fips-updates`, `livepatch`, `cis`, and `ros`) using `pro enable`, with error handling to log failures if a feature cannot be enabled.